### PR TITLE
Fix panel not populating if mismatch between available worlds and sto…

### DIFF
--- a/src/main/java/com/togcrowdsourcing/ui/WorldSwitcherPanel.java
+++ b/src/main/java/com/togcrowdsourcing/ui/WorldSwitcherPanel.java
@@ -220,18 +220,11 @@ class WorldSwitcherPanel extends PluginPanel
 		final GridBagConstraints c = new GridBagConstraints();
 		final String[] messages = new String[]
 		{
-//			" ",
-//			"    Worlds have reset!",
-//			" ",
-//			"    Please help to gather data",
-//			"    by hopping worlds :)",
 			" ",
-			"    There is currently an issue",
-			"    displaying worlds in the plugin.",
-			"    We are currently looking into a",
-			"    fix, but for now, please visit",
-			"    https://togcrowdsourcing.com/",
-			"    for a list of current worlds."
+			"    Worlds have reset!",
+			" ",
+			"    Please help to gather data",
+			"    by hopping worlds :)",
 		};
 
 		for (String message : messages)
@@ -293,8 +286,6 @@ class WorldSwitcherPanel extends PluginPanel
 		{
 			WorldData worldData = worldDataList.get(i);
 			World world = worldResult.findWorld(worldData.getWorld_number());
-			if (world == null) { return; }
-
 			if (shouldWorldBeSkipped(world, worldData, config)) { continue; }
 
 			boolean isCurrentWorld = worldData.getWorld_number() == worldHopper.getCurrentWorld() && worldHopper.getLastWorld() != 0;


### PR DESCRIPTION
Looks like there was a mismatch between the available worlds and the worlds that were stored by the plugin.

It's possible that earlier in the week, these worlds were running, but were taken down.

There was a spot in the code that would not populate the list if the api server gave the client a world that is not currently running.

This check should never have been a return, it should have been a continue at most. That logic is handled by `shouldWorldBeSkipped` so the check was removed.